### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories    = ["algorithms", "science"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-statrs = "0.13.0"
+statrs = "0.14.0"
 num-traits = "0.2.12"
 ndarray = "0.13.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ num-traits = "0.2.12"
 ndarray = "0.15.6"
 
 [dev-dependencies]
-rand = "0.7.3"
-rand_distr = "0.3.0"
+rand = "0.8.5"
+rand_distr = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories    = ["algorithms", "science"]
 [dependencies]
 statrs = "0.16.0"
 num-traits = "0.2.12"
-ndarray = "0.13.1"
+ndarray = "0.15.6"
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories    = ["algorithms", "science"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-statrs = "0.14.0"
+statrs = "0.16.0"
 num-traits = "0.2.12"
 ndarray = "0.13.1"
 

--- a/examples/ks.rs
+++ b/examples/ks.rs
@@ -1,6 +1,6 @@
 use rand_distr::{StudentT, Distribution};
 use statest::ks::*;
-use statrs::distribution::{StudentsT, Exponential, Normal};
+use statrs::distribution::{Exp, Normal, StudentsT};
 
 fn main() {
     let t = StudentT::new(1.0).unwrap();
@@ -8,7 +8,7 @@ fn main() {
                          .collect::<Vec<f64>>();
     let tdist = StudentsT::new(0.0, 1.0, 1.0).unwrap();
     let ndist = Normal::new(0.0, 1.0).unwrap();
-    let edist = Exponential::new(1.0).unwrap();
+    let edist = Exp::new(1.0).unwrap();
     println!("StudentT? {}", t_vec.ks1(&tdist, 0.05));
     println!("Normal? {}", t_vec.ks1(&ndist, 0.05));
     println!("Exponential? {}", t_vec.ks1(&edist, 0.05));

--- a/src/chi2.rs
+++ b/src/chi2.rs
@@ -65,7 +65,7 @@ impl Chi2Indep {
             .and(&self.cross)
             .and(&self.xi.broadcast((self.c, self.r)).unwrap().t())
             .and(&self.xj.broadcast((self.r, self.c)).unwrap())
-            .apply(|a, &b, &c, &d| {
+            .for_each(|a, &b, &c, &d| {
                 let ijn = (c * d) as f64 / self.n as f64;
                 let nume = b as f64 - ijn;
                 *a = nume * nume / ijn;

--- a/src/chi2.rs
+++ b/src/chi2.rs
@@ -1,6 +1,6 @@
 use ndarray::*;
 use num_traits::Float;
-use statrs::distribution::{ChiSquared, Univariate};
+use statrs::distribution::{ChiSquared, ContinuousCDF};
 
 use crate::cast::*;
 

--- a/src/ks.rs
+++ b/src/ks.rs
@@ -2,7 +2,7 @@
 
 use ndarray::*;
 use num_traits::Float;
-use statrs::distribution::Univariate;
+use statrs::distribution::ContinuousCDF;
 
 use crate::cast::*;
 
@@ -28,7 +28,7 @@ impl KSTest {
     }
 
     /// Kolmogorov–Smirnov test which returns probability `prob` and test statistic D `d`. 
-    pub fn ks1<T: Univariate<f64, f64>>(&self, dist: &T) -> (f64, f64) {
+    pub fn ks1<T: ContinuousCDF<f64, f64>>(&self, dist: &T) -> (f64, f64) {
         let mut d = 0.0;
         let mut f_old = 0.0;
 
@@ -55,11 +55,11 @@ impl KSTest {
 /// Trait for Kolmogorov–Smirnov test.
 pub trait KSVec<T: Float> {
     /// Kolmogorov–Smirnov test. If `p` <= `prob`, then returns `true`.
-    fn ks1<S: Univariate<f64, f64>>(&self, dist: &S, p: T) -> bool;
+    fn ks1<S: ContinuousCDF<f64, f64>>(&self, dist: &S, p: T) -> bool;
 }
 
 impl KSVec<f64> for Vec<f64> {
-    fn ks1<S: Univariate<f64, f64>>(&self, dist: &S, p: f64) -> bool {
+    fn ks1<S: ContinuousCDF<f64, f64>>(&self, dist: &S, p: f64) -> bool {
         let ks = KSTest::new(&self);
         let (prob, _) = ks.ks1(dist);
         prob >= p
@@ -67,19 +67,19 @@ impl KSVec<f64> for Vec<f64> {
 }
 
 impl KSVec<f32> for Vec<f32> {
-    fn ks1<S: Univariate<f64, f64>>(&self, dist: &S, p: f32) -> bool {
+    fn ks1<S: ContinuousCDF<f64, f64>>(&self, dist: &S, p: f32) -> bool {
         self.to_vec_f64().ks1(dist, p as f64)
     }
 }
 
 impl<U: Data<Elem = f64>> KSVec<f64> for ArrayBase<U, Ix1> {
-    fn ks1<S: Univariate<f64, f64>>(&self, dist: &S, p: f64) -> bool {
+    fn ks1<S: ContinuousCDF<f64, f64>>(&self, dist: &S, p: f64) -> bool {
         self.to_vec().ks1(dist, p)
     }
 }
 
 impl<U: Data<Elem = f32>> KSVec<f32> for ArrayBase<U, Ix1> {
-    fn ks1<S: Univariate<f64, f64>>(&self, dist: &S, p: f32) -> bool {
+    fn ks1<S: ContinuousCDF<f64, f64>>(&self, dist: &S, p: f32) -> bool {
         self.to_vec().ks1(dist, p)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! ```rust
 //! use rand_distr::{StudentT, Distribution};
 //! use statest::ks::*;
-//! use statrs::distribution::{StudentsT, Exponential, Normal};
+//! use statrs::distribution::{StudentsT, Exp, Normal};
 //! 
 //! fn main() {
 //!     let t = StudentT::new(1.0).unwrap();
@@ -33,7 +33,7 @@
 //!                          .collect::<Vec<f64>>();
 //!     let tdist = StudentsT::new(0.0, 1.0, 1.0).unwrap();
 //!     let ndist = Normal::new(0.0, 1.0).unwrap();
-//!     let edist = Exponential::new(1.0).unwrap();
+//!     let edist = Exp::new(1.0).unwrap();
 //!     println!("StudentT? {}", t_vec.ks1(&tdist, 0.05)); // true
 //!     println!("Normal? {}", t_vec.ks1(&ndist, 0.05)); // false
 //!     println!("Exponential? {}", t_vec.ks1(&edist, 0.05)); // false

--- a/src/numerical.rs
+++ b/src/numerical.rs
@@ -1,13 +1,13 @@
 //! Numerical calculation for tests.
 
 use num_traits::Float;
-use statrs::distribution::Univariate;
+use statrs::distribution::ContinuousCDF;
 
 /// Calculate derivative.
 pub fn deriv<S, T>(dist: &T, x: S, h: S) -> S
 where
     S: Float,
-    T: Univariate<S, S>
+    T: ContinuousCDF<S, S>,
 {
     let fx = dist.cdf(x);
     deriv_with_fx(dist, x, fx, h)
@@ -17,7 +17,7 @@ where
 pub fn deriv_with_fx<S, T>(dist: &T, x: S, fx: S, h: S) -> S
 where
     S: Float,
-    T: Univariate<S, S>
+    T: ContinuousCDF<S, S>,
 {
     let fx_h = dist.cdf(x + h);
     (fx_h - fx) / h
@@ -27,7 +27,7 @@ where
 pub fn newton<S, T>(dist: &T, y: S, mu: S, epsilon: S) -> S 
 where
     S: Float,
-    T: Univariate<S, S>
+    T: ContinuousCDF<S, S>,
 {
     let fx0 = dist.cdf(mu);
     if fx0 + epsilon >= y && fx0 - epsilon <= y {

--- a/src/ttest.rs
+++ b/src/ttest.rs
@@ -2,8 +2,8 @@
 
 use ndarray::*;
 use num_traits::Float;
+use statrs::distribution::{ContinuousCDF, StudentsT};
 use statrs::statistics::Statistics;
-use statrs::distribution::{StudentsT, Univariate};
 
 use crate::cast::*;
 


### PR DESCRIPTION
This upgrades all dependencies to their latest versions, and deals with some breaking changes in them.

I confirmed that the doctests pass, and the examples produce the same outputs. (though before and after, the Kolmogorov-Smirnov example sometimes reports false when comparing with the Student T distribution, because the data is randomly generated each run)

Upgrading statrs in particular will allow upgrading nalgebra to fix [RUSTSEC-2021-0070](https://rustsec.org/advisories/RUSTSEC-2021-0070.html) (though this crate does not use the vulnerable serde interface at all).